### PR TITLE
Fixes failure to launch "new user" / "popular" screens post onboard

### DIFF
--- a/aether-core/aether/client/src/app/components/locations/onboardscope/onboard6.vue
+++ b/aether-core/aether/client/src/app/components/locations/onboardscope/onboard6.vue
@@ -30,12 +30,14 @@ export default {
   },
   methods: {
     toNewUser(this: any) {
-      this.$router.push('/newuser')
-      fe.SetOnboardComplete(true, function() {})
+      fe.SetOnboardComplete(true, () => {
+        this.$router.push('/newuser')
+      })
     },
     toApp(this: any) {
-      this.$router.push('/popular')
-      fe.SetOnboardComplete(true, function() {})
+      fe.SetOnboardComplete(true, () => {
+        this.$router.push('/popular')
+      })
     },
   },
 }


### PR DESCRIPTION
This is a fix for the issue I reported here: https://meta.getaether.net/t/aether-fails-to-show-new-user-modal-after-saying-yes-to-onboarding-question-create-new-user/350

The problem was that a navigation guard was in place preventing navigation outside onboarding screens until onboarding was set to complete in VueX store.

This fix ensures that router.push is called only *after* onboarding is successfully set to complete.

There is a slight issue with scroll position in the "create new user" screen, where the screen's title is not visible, but it looks alright and feels quite natural at the default window size so I think it's fine.

(It might be good to make a mixin for resetting the scroll position and use that just to be sure. I can do that if you like, but I thought you might want to give me guidance on the best way to do it, if in fact it's important.)